### PR TITLE
Fix casting error

### DIFF
--- a/lib/src/parser/parser.dart
+++ b/lib/src/parser/parser.dart
@@ -297,7 +297,7 @@ class BinaryReconstructor {
     this.buffers.add(binData);
     if (this.buffers.length == this.reconPack['attachments']) {
       // done with buffer list
-      var packet = Binary.reconstructPacket(this.reconPack, this.buffers);
+      var packet = Binary.reconstructPacket(this.reconPack, this.buffers.cast<List<int>>()));
       this.finishedReconstruction();
       return packet;
     }


### PR DESCRIPTION
When receiving binary data List<dynamic> isn't cased to List<List<int>> and it crashes, this little PR fixes it