### PR TITLE
fixed RangeError

### DIFF
--- a/lib/src/parser/parser.dart
+++ b/lib/src/parser/parser.dart
@@ -210,9 +210,9 @@ class Decoder extends EventEmitter {
     if (i < endLen - 1 && '/' == str[i + 1]) {
       var start = i + 1;
       while (++i > 0) {
+        if (i == str.length) break;
         var c = str[i];
         if ("," == c) break;
-        if (i == str.length) break;
       }
       p['nsp'] = str.substring(start, i);
     } else {


### PR DESCRIPTION
The parser first accesses the next character before checking if is not at the end of the string causing a RangeError.
This exception occured only, if I try to connect `socket_io_common v2.*` to a `socket_io Server v2.*`, which is not supported.
Changing the order yield then yields the correct warning that the two versions are incompatible.