### PR TITLE
Fix ByteBuffer cast to Uint8List

### DIFF
--- a/lib/src/engine/parser/decodePacket.dart
+++ b/lib/src/engine/parser/decodePacket.dart
@@ -10,7 +10,7 @@ import 'commons.dart';
 mapBinary(data, binaryType) {
   final isBuffer = data is ByteBuffer;
   if (binaryType == 'arraybuffer') {
-    return isBuffer ? Uint8List.fromList(data as List<int>) : data;
+    return isBuffer ? data.asUint8List() : data;
   }
   return data;
 }


### PR DESCRIPTION
Hello 😊
in `mapBinary` function, if data is a ByteBuffer, there's a an error at the `as List<Int>` casting operation.
Since `ByteBuffer` has an `asUint8List()` function, so I made the change.

Thanks